### PR TITLE
Add NTLM support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Microsoft
+Copyright (c) Microsoft Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,21 @@
-The MIT License (MIT)
+Visual Studio Team Services Client for Node.js
 
 Copyright (c) Microsoft Corporation
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+All rights reserved.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+MIT License
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
 
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -1,0 +1,69 @@
+
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+Do Not Translate or Localize
+
+Visual Studio Team Services Client for Node.js incorporates third party material
+from the projects listed below. The original copyright notice and the license
+under which Microsoft received such third party material are set forth below.
+Microsoft reserves all other rights not expressly granted, whether by implication,
+estoppel or otherwise.
+
+
+1.	httpntlm (https://github.com/SamDecrock/node-http-ntlm)
+2.	underscore (https://github.com/jashkenas/underscore)
+
+
+%% httpntlm NOTICES, INFORMATION, AND LICENSE BEGIN HERE
+=========================================
+The MIT License (MIT)
+
+Copyright (c) 2013 Sam (Sam Decrock)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+=========================================
+END OF httpntlm NOTICES, INFORMATION, AND LICENSE
+
+%% underscore NOTICES, INFORMATION, AND LICENSE BEGIN HERE
+=========================================
+Copyright (c) 2009-2016 Jeremy Ashkenas, DocumentCloud and Investigative
+Reporters & Editors
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+=========================================
+END OF underscore NOTICES, INFORMATION, AND LICENSE
+
+

--- a/api/HttpClient.ts
+++ b/api/HttpClient.ts
@@ -148,28 +148,22 @@ export class HttpClient implements ifm.IHttpClient {
 
     request(protocol: any, options: any, objs: any, onResult: (err: any, res: http.ClientResponse, contents: string) => void): void {
         // Set up a callback to pass off 401s to an authentication handler that can deal with it
-        let self = this;
-        var callback = function (err, res, contents) {
-            if (res !== undefined && res.statusCode === 401) {
-                // Find the first authentication handler that can handle the 401
-                var authHandler;
-                if (self.handlers) {
-                    self.handlers.some(function (handler, index, handlers) {
-                        // Find the first one that can handle the auth based on the headers
-                        if (handler.canHandleAuthentication(res.headers)) {
-                            authHandler = handler;
-                            return true;
-                        }
-                        return false;
-                    });
-                }
-                if (authHandler !== undefined) {
-                    authHandler.handleAuthentication(self, protocol, options, objs, onResult);
-                } else {
-                    // No auth handler found, call onResult normally
-                    onResult(err, res, contents);
-                }
+        var callback = (err: any, res: http.ClientResponse, contents: string) => {
+            var authHandler;
+            if (this.handlers) {
+                this.handlers.some(function (handler, index, handlers) {
+                    // Find the first one that can handle the auth based on the response
+                    if (handler.canHandleAuthentication(res)) {
+                        authHandler = handler;
+                        return true;
+                    }
+                    return false;
+                });
+            }
+            if (authHandler !== undefined) {
+                authHandler.handleAuthentication(this, protocol, options, objs, onResult);
             } else {
+                // No auth handler found, call onResult normally
                 onResult(err, res, contents);
             }
         };

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -18,6 +18,7 @@ import releasem = require('./ReleaseApi');
 import apivm = require('./handlers/apiversion');
 import basicm = require('./handlers/basiccreds');
 import bearm = require('./handlers/bearertoken');
+import ntlmm = require('./handlers/ntlm');
 
 /**
  * Methods to return handler objects (see handlers folder)
@@ -28,6 +29,10 @@ export function getVersionHandler(apiVersion: string) {
 
 export function getBasicHandler(username: string, password: string) {
     return new basicm.BasicCredentialHandler(username, password);
+}
+
+export function getNtlmHandler(username: string, password: string, workstation?: string, domain?: string) {
+    return new ntlmm.NtlmCredentialHandler(username, password, workstation, domain);
 }
 
 export function getBearerHandler(token) {

--- a/api/handlers/apiversion.ts
+++ b/api/handlers/apiversion.ts
@@ -19,4 +19,12 @@ export class ApiVersionHandler implements VsoBaseInterfaces.IRequestHandler {
     		options.headers["Accept"] = options.headers['Accept'] + '; api-version=' + this.apiVersion;	
     	}
     }
+
+    // This handler cannot handle 401
+    canHandleAuthentication(headers: any): boolean {
+        return false;
+    }
+
+    handleAuthentication(httpClient, protocol, options, objs, finalCallback): void {
+    }
 }

--- a/api/handlers/apiversion.ts
+++ b/api/handlers/apiversion.ts
@@ -21,7 +21,7 @@ export class ApiVersionHandler implements VsoBaseInterfaces.IRequestHandler {
     }
 
     // This handler cannot handle 401
-    canHandleAuthentication(headers: any): boolean {
+    canHandleAuthentication(res: VsoBaseInterfaces.IHttpResponse): boolean {
         return false;
     }
 

--- a/api/handlers/basiccreds.ts
+++ b/api/handlers/basiccreds.ts
@@ -22,7 +22,7 @@ export class BasicCredentialHandler implements VsoBaseInterfaces.IRequestHandler
     }
 
     // This handler cannot handle 401
-    canHandleAuthentication(headers: any): boolean {
+    canHandleAuthentication(res: VsoBaseInterfaces.IHttpResponse): boolean {
         return false;
     }
 

--- a/api/handlers/basiccreds.ts
+++ b/api/handlers/basiccreds.ts
@@ -20,4 +20,12 @@ export class BasicCredentialHandler implements VsoBaseInterfaces.IRequestHandler
         options.headers['Authorization'] = 'Basic ' + new Buffer(this.username + ':' + this.password).toString('base64');
         options.headers['X-TFS-FedAuthRedirect'] = 'Suppress';
     }
+
+    // This handler cannot handle 401
+    canHandleAuthentication(headers: any): boolean {
+        return false;
+    }
+
+    handleAuthentication(httpClient, protocol, options, objs, finalCallback): void {
+    }
 }

--- a/api/handlers/bearertoken.ts
+++ b/api/handlers/bearertoken.ts
@@ -18,4 +18,12 @@ export class BearerCredentialHandler implements VsoBaseInterfaces.IRequestHandle
         options.headers['Authorization'] = 'Bearer ' + this.token;
         options.headers['X-TFS-FedAuthRedirect'] = 'Suppress';
     }
+
+    // This handler cannot handle 401
+    canHandleAuthentication(headers: any): boolean {
+        return false;
+    }
+
+    handleAuthentication(httpClient, protocol, options, objs, finalCallback): void {
+    }
 }

--- a/api/handlers/bearertoken.ts
+++ b/api/handlers/bearertoken.ts
@@ -20,7 +20,7 @@ export class BearerCredentialHandler implements VsoBaseInterfaces.IRequestHandle
     }
 
     // This handler cannot handle 401
-    canHandleAuthentication(headers: any): boolean {
+    canHandleAuthentication(res: VsoBaseInterfaces.IHttpResponse): boolean {
         return false;
     }
 

--- a/api/handlers/ntlm.ts
+++ b/api/handlers/ntlm.ts
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/// <reference path="../../node/node.d.ts"/>
+
+import VsoBaseInterfaces = require('../interfaces/common/VsoBaseInterfaces');
+
+import http = require("http");
+import https = require("https");
+var _ = require("underscore");
+var ntlm = require("../opensource/node-http-ntlm/ntlm");
+
+export class NtlmCredentialHandler implements VsoBaseInterfaces.IRequestHandler {
+    username: string;
+    password: string;
+    workstation: string;
+    domain: string;
+
+    constructor(username: string, password: string,  domain?: string, workstation?: string) {
+        this.username = username;
+        this.password = password;
+        if (domain !== undefined) {
+            this.domain = domain;
+        }
+        if (workstation !== undefined) {
+            this.workstation = workstation;
+        }
+    }
+
+    prepareRequest(options:any): void {
+        // No headers or options need to be set.  We keep the credentials on the handler itself.
+    }
+
+    canHandleAuthentication(headers: any): boolean {
+        // Ensure that we're talking NTLM here
+        // Once we have the www-authenticate header, split it so we can ensure we can talk NTLM
+        var wwwAuthenticate = headers['www-authenticate'];
+        if (wwwAuthenticate !== undefined) {
+            var mechanisms = wwwAuthenticate.split(', ');
+            var idx =  mechanisms.indexOf("NTLM");
+            if (idx >= 0) {
+                // Check specifically for 'NTLM' since www-authenticate header can also contain
+                // the Authorization value to use in the form of 'NTLM TlRMTVNT....AAAADw=='
+                if (mechanisms[idx].length == 4) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    // The following method is an adaptation of code found at https://github.com/SamDecrock/node-http-ntlm/blob/master/httpntlm.js
+    handleAuthentication(httpClient, protocol, options, objs, finalCallback): void {
+        // Set up the headers for NTLM authentication
+        var ntlmOptions = _.extend(options, {
+            username: this.username,
+            password: this.password,
+            domain: (this.domain !== undefined) ? this.domain : '',
+            workstation: (this.workstation !== undefined) ? this.workstation : ''
+        });
+        var keepaliveAgent;
+        if (httpClient.isSsl === true) {
+            keepaliveAgent = new https.Agent({});
+        } else {
+            keepaliveAgent = new http.Agent({ keepAlive: true });
+        }
+        let self = this;
+        // The following pattern of sending the type1 message following immediately (in a setImmediate) is
+        // critical for the NTLM exchange to happen.  If we removed setImmediate (or call in a different manner)
+        // the NTLM exchange will always fail with a 401.
+        this.sendType1Message(httpClient, protocol, ntlmOptions, objs, keepaliveAgent, function (err, res) {
+            if (err) {
+                return finalCallback(err, null, null);
+            }
+            setImmediate(function () {
+                self.sendType3Message(httpClient, protocol, ntlmOptions, objs, keepaliveAgent, res, finalCallback);
+            });
+        });
+    }
+
+    // The following method is an adaptation of code found at https://github.com/SamDecrock/node-http-ntlm/blob/master/httpntlm.js
+    private sendType1Message(httpClient, protocol, options, objs, keepaliveAgent, callback): void {
+        var type1msg = ntlm.createType1Message(options);
+        var type1options = {
+            headers: {
+                'Connection': 'keep-alive',
+                'Authorization': type1msg
+            },
+            timeout: options.timeout || 0,
+            agent: keepaliveAgent,
+             // don't redirect because http could change to https which means we need to change the keepaliveAgent
+            allowRedirects: false
+        };
+        type1options = _.extend(type1options, _.omit(options, 'headers'));
+        httpClient.requestInternal(protocol, type1options, objs, callback);
+    }
+
+    // The following method is an adaptation of code found at https://github.com/SamDecrock/node-http-ntlm/blob/master/httpntlm.js
+    private sendType3Message(httpClient, protocol, options, objs, keepaliveAgent, res, callback): void {
+        if (!res.headers['www-authenticate'])
+            return callback(new Error('www-authenticate not found on response of second request'));
+        // parse type2 message from server:
+        var type2msg = ntlm.parseType2Message(res.headers['www-authenticate']);
+        // create type3 message:
+        var type3msg = ntlm.createType3Message(type2msg, options);
+        // build type3 request:
+        var type3options = {
+            headers: {
+                'Authorization': type3msg
+            },
+            allowRedirects: false,
+            agent: keepaliveAgent
+        };
+        // pass along other options:
+        type3options.headers = _.extend(type3options.headers, options.headers);
+        type3options = _.extend(type3options, _.omit(options, 'headers'));
+        // send type3 message to server:
+        httpClient.requestInternal(protocol, type3options, objs, callback);
+    }
+}

--- a/api/interfaces/common/VsoBaseInterfaces.ts
+++ b/api/interfaces/common/VsoBaseInterfaces.ts
@@ -54,6 +54,8 @@ export interface IBasicCredentials {
 
 export interface IRequestHandler {
     prepareRequest(options: any): void;
+    canHandleAuthentication(headers: any): boolean;
+    handleAuthentication(httpClient, protocol, options, objs, finalCallback): void;
 }
 
 export interface IHttpResponse {

--- a/api/interfaces/common/VsoBaseInterfaces.ts
+++ b/api/interfaces/common/VsoBaseInterfaces.ts
@@ -54,7 +54,7 @@ export interface IBasicCredentials {
 
 export interface IRequestHandler {
     prepareRequest(options: any): void;
-    canHandleAuthentication(headers: any): boolean;
+    canHandleAuthentication(res: IHttpResponse): boolean;
     handleAuthentication(httpClient, protocol, options, objs, finalCallback): void;
 }
 

--- a/api/opensource/node-http-ntlm/ntlm.js
+++ b/api/opensource/node-http-ntlm/ntlm.js
@@ -1,0 +1,390 @@
+var crypto = require('crypto');
+
+var flags = {
+	NTLM_NegotiateUnicode                :  0x00000001,
+	NTLM_NegotiateOEM                    :  0x00000002,
+	NTLM_RequestTarget                   :  0x00000004,
+	NTLM_Unknown9                        :  0x00000008,
+	NTLM_NegotiateSign                   :  0x00000010,
+	NTLM_NegotiateSeal                   :  0x00000020,
+	NTLM_NegotiateDatagram               :  0x00000040,
+	NTLM_NegotiateLanManagerKey          :  0x00000080,
+	NTLM_Unknown8                        :  0x00000100,
+	NTLM_NegotiateNTLM                   :  0x00000200,
+	NTLM_NegotiateNTOnly                 :  0x00000400,
+	NTLM_Anonymous                       :  0x00000800,
+	NTLM_NegotiateOemDomainSupplied      :  0x00001000,
+	NTLM_NegotiateOemWorkstationSupplied :  0x00002000,
+	NTLM_Unknown6                        :  0x00004000,
+	NTLM_NegotiateAlwaysSign             :  0x00008000,
+	NTLM_TargetTypeDomain                :  0x00010000,
+	NTLM_TargetTypeServer                :  0x00020000,
+	NTLM_TargetTypeShare                 :  0x00040000,
+	NTLM_NegotiateExtendedSecurity       :  0x00080000,
+	NTLM_NegotiateIdentify               :  0x00100000,
+	NTLM_Unknown5                        :  0x00200000,
+	NTLM_RequestNonNTSessionKey          :  0x00400000,
+	NTLM_NegotiateTargetInfo             :  0x00800000,
+	NTLM_Unknown4                        :  0x01000000,
+	NTLM_NegotiateVersion                :  0x02000000,
+	NTLM_Unknown3                        :  0x04000000,
+	NTLM_Unknown2                        :  0x08000000,
+	NTLM_Unknown1                        :  0x10000000,
+	NTLM_Negotiate128                    :  0x20000000,
+	NTLM_NegotiateKeyExchange            :  0x40000000,
+	NTLM_Negotiate56                     :  0x80000000
+};
+var typeflags = {
+	NTLM_TYPE1_FLAGS : 	  flags.NTLM_NegotiateUnicode
+						+ flags.NTLM_NegotiateOEM
+						+ flags.NTLM_RequestTarget
+						+ flags.NTLM_NegotiateNTLM
+						+ flags.NTLM_NegotiateOemDomainSupplied
+						+ flags.NTLM_NegotiateOemWorkstationSupplied
+						+ flags.NTLM_NegotiateAlwaysSign
+						+ flags.NTLM_NegotiateExtendedSecurity
+						+ flags.NTLM_NegotiateVersion
+						+ flags.NTLM_Negotiate128
+						+ flags.NTLM_Negotiate56,
+
+	NTLM_TYPE2_FLAGS :    flags.NTLM_NegotiateUnicode
+						+ flags.NTLM_RequestTarget
+						+ flags.NTLM_NegotiateNTLM
+						+ flags.NTLM_NegotiateAlwaysSign
+						+ flags.NTLM_NegotiateExtendedSecurity
+						+ flags.NTLM_NegotiateTargetInfo
+						+ flags.NTLM_NegotiateVersion
+						+ flags.NTLM_Negotiate128
+						+ flags.NTLM_Negotiate56
+};
+
+function createType1Message(options){
+	var domain = escape(options.domain.toUpperCase());
+	var workstation = escape(options.workstation.toUpperCase());
+	var protocol = 'NTLMSSP\0';
+
+	var BODY_LENGTH = 40;
+
+	var type1flags = typeflags.NTLM_TYPE1_FLAGS;
+	if(!domain || domain === '')
+		type1flags = type1flags - flags.NTLM_NegotiateOemDomainSupplied;
+
+	var pos = 0;
+	var buf = new Buffer(BODY_LENGTH + domain.length + workstation.length);
+
+
+	buf.write(protocol, pos, protocol.length); pos += protocol.length; // protocol
+	buf.writeUInt32LE(1, pos); pos += 4;          // type 1
+	buf.writeUInt32LE(type1flags, pos); pos += 4; // TYPE1 flag
+
+	buf.writeUInt16LE(domain.length, pos); pos += 2; // domain length
+	buf.writeUInt16LE(domain.length, pos); pos += 2; // domain max length
+	buf.writeUInt32LE(BODY_LENGTH + workstation.length, pos); pos += 4; // domain buffer offset
+
+	buf.writeUInt16LE(workstation.length, pos); pos += 2; // workstation length
+	buf.writeUInt16LE(workstation.length, pos); pos += 2; // workstation max length
+	buf.writeUInt32LE(BODY_LENGTH, pos); pos += 4; // workstation buffer offset
+
+	buf.writeUInt8(5, pos); pos += 1;      //ProductMajorVersion
+	buf.writeUInt8(1, pos); pos += 1;      //ProductMinorVersion
+	buf.writeUInt16LE(2600, pos); pos += 2; //ProductBuild
+
+	buf.writeUInt8(0 , pos); pos += 1; //VersionReserved1
+	buf.writeUInt8(0 , pos); pos += 1; //VersionReserved2
+	buf.writeUInt8(0 , pos); pos += 1; //VersionReserved3
+	buf.writeUInt8(15, pos); pos += 1; //NTLMRevisionCurrent
+
+	buf.write(workstation, pos, workstation.length, 'ascii'); pos += workstation.length; // workstation string
+	buf.write(domain     , pos, domain.length     , 'ascii'); pos += domain.length;
+
+	return 'NTLM ' + buf.toString('base64');
+}
+
+function parseType2Message(rawmsg, callback){
+	var match = rawmsg.match(/NTLM (.+)?/);
+	if(!match || !match[1])
+		return callback(new Error("Couldn't find NTLM in the message type2 comming from the server"));
+
+	var buf = new Buffer(match[1], 'base64');
+
+	var msg = {};
+
+	msg.signature = buf.slice(0, 8);
+	msg.type = buf.readInt16LE(8);
+
+	if(msg.type != 2)
+		return callback(new Error("Server didn't return a type 2 message"));
+
+	msg.targetNameLen = buf.readInt16LE(12);
+	msg.targetNameMaxLen = buf.readInt16LE(14);
+	msg.targetNameOffset = buf.readInt32LE(16);
+	msg.targetName  = buf.slice(msg.targetNameOffset, msg.targetNameOffset + msg.targetNameMaxLen);
+
+    msg.negotiateFlags = buf.readInt32LE(20);
+    msg.serverChallenge = buf.slice(24, 32);
+    msg.reserved = buf.slice(32, 40);
+
+    if(msg.negotiateFlags & flags.NTLM_NegotiateTargetInfo){
+    	msg.targetInfoLen = buf.readInt16LE(40);
+    	msg.targetInfoMaxLen = buf.readInt16LE(42);
+    	msg.targetInfoOffset = buf.readInt32LE(44);
+    	msg.targetInfo = buf.slice(msg.targetInfoOffset, msg.targetInfoOffset + msg.targetInfoLen);
+    }
+	return msg;
+}
+
+function createType3Message(msg2, options){
+	var nonce = msg2.serverChallenge;
+	var username = options.username;
+	var password = options.password;
+	var negotiateFlags = msg2.negotiateFlags;
+
+	var isUnicode = negotiateFlags & flags.NTLM_NegotiateUnicode;
+	var isNegotiateExtendedSecurity = negotiateFlags & flags.NTLM_NegotiateExtendedSecurity;
+
+	var BODY_LENGTH = 72;
+
+	var domainName = escape(options.domain.toUpperCase());
+	var workstation = escape(options.workstation.toUpperCase());
+
+	var workstationBytes, domainNameBytes, usernameBytes, encryptedRandomSessionKeyBytes;
+
+	var encryptedRandomSessionKey = "";
+	if(isUnicode){
+		workstationBytes = new Buffer(workstation, 'utf16le');
+		domainNameBytes = new Buffer(domainName, 'utf16le');
+		usernameBytes = new Buffer(username, 'utf16le');
+		encryptedRandomSessionKeyBytes = new Buffer(encryptedRandomSessionKey, 'utf16le');
+	}else{
+		workstationBytes = new Buffer(workstation, 'ascii');
+		domainNameBytes = new Buffer(domainName, 'ascii');
+		usernameBytes = new Buffer(username, 'ascii');
+		encryptedRandomSessionKeyBytes = new Buffer(encryptedRandomSessionKey, 'ascii');
+	}
+
+	var lmChallengeResponse = calc_resp(create_LM_hashed_password_v1(password), nonce);
+	var ntChallengeResponse = calc_resp(create_NT_hashed_password_v1(password), nonce);
+
+	if(isNegotiateExtendedSecurity){
+		var pwhash = create_NT_hashed_password_v1(password);
+	 	var clientChallenge = "";
+	 	for(var i=0; i < 8; i++){
+	 		clientChallenge += String.fromCharCode( Math.floor(Math.random()*256) );
+	   	}
+	   	var clientChallengeBytes = new Buffer(clientChallenge, 'ascii');
+	    var challenges = ntlm2sr_calc_resp(pwhash, nonce, clientChallengeBytes);
+	    lmChallengeResponse = challenges.lmChallengeResponse;
+	    ntChallengeResponse = challenges.ntChallengeResponse;
+	}
+
+	var signature = 'NTLMSSP\0';
+
+	var pos = 0;
+	var buf = new Buffer(BODY_LENGTH + domainNameBytes.length + usernameBytes.length + workstationBytes.length + lmChallengeResponse.length + ntChallengeResponse.length + encryptedRandomSessionKeyBytes.length);
+
+	buf.write(signature, pos, signature.length); pos += signature.length;
+	buf.writeUInt32LE(3, pos); pos += 4;          // type 1
+
+	buf.writeUInt16LE(lmChallengeResponse.length, pos); pos += 2; // LmChallengeResponseLen
+	buf.writeUInt16LE(lmChallengeResponse.length, pos); pos += 2; // LmChallengeResponseMaxLen
+	buf.writeUInt32LE(BODY_LENGTH + domainNameBytes.length + usernameBytes.length + workstationBytes.length, pos); pos += 4; // LmChallengeResponseOffset
+
+	buf.writeUInt16LE(ntChallengeResponse.length, pos); pos += 2; // NtChallengeResponseLen
+	buf.writeUInt16LE(ntChallengeResponse.length, pos); pos += 2; // NtChallengeResponseMaxLen
+	buf.writeUInt32LE(BODY_LENGTH + domainNameBytes.length + usernameBytes.length + workstationBytes.length + lmChallengeResponse.length, pos); pos += 4; // NtChallengeResponseOffset
+
+	buf.writeUInt16LE(domainNameBytes.length, pos); pos += 2; // DomainNameLen
+	buf.writeUInt16LE(domainNameBytes.length, pos); pos += 2; // DomainNameMaxLen
+	buf.writeUInt32LE(BODY_LENGTH, pos); pos += 4; 			  // DomainNameOffset
+
+	buf.writeUInt16LE(usernameBytes.length, pos); pos += 2; // UserNameLen
+	buf.writeUInt16LE(usernameBytes.length, pos); pos += 2; // UserNameMaxLen
+	buf.writeUInt32LE(BODY_LENGTH + domainNameBytes.length, pos); pos += 4; // UserNameOffset
+
+	buf.writeUInt16LE(workstationBytes.length, pos); pos += 2; // WorkstationLen
+	buf.writeUInt16LE(workstationBytes.length, pos); pos += 2; // WorkstationMaxLen
+	buf.writeUInt32LE(BODY_LENGTH + domainNameBytes.length + usernameBytes.length, pos); pos += 4; // WorkstationOffset
+
+	buf.writeUInt16LE(encryptedRandomSessionKeyBytes.length, pos); pos += 2; // EncryptedRandomSessionKeyLen
+	buf.writeUInt16LE(encryptedRandomSessionKeyBytes.length, pos); pos += 2; // EncryptedRandomSessionKeyMaxLen
+	buf.writeUInt32LE(BODY_LENGTH + domainNameBytes.length + usernameBytes.length + workstationBytes.length + lmChallengeResponse.length + ntChallengeResponse.length, pos); pos += 4; // EncryptedRandomSessionKeyOffset
+
+	buf.writeUInt32LE(typeflags.NTLM_TYPE2_FLAGS, pos); pos += 4; // NegotiateFlags
+
+	buf.writeUInt8(5, pos); pos++; // ProductMajorVersion
+	buf.writeUInt8(1, pos); pos++; // ProductMinorVersion
+	buf.writeUInt16LE(2600, pos); pos += 2; // ProductBuild
+	buf.writeUInt8(0, pos); pos++; // VersionReserved1
+	buf.writeUInt8(0, pos); pos++; // VersionReserved2
+	buf.writeUInt8(0, pos); pos++; // VersionReserved3
+	buf.writeUInt8(15, pos); pos++; // NTLMRevisionCurrent
+
+	domainNameBytes.copy(buf, pos); pos += domainNameBytes.length;
+	usernameBytes.copy(buf, pos); pos += usernameBytes.length;
+	workstationBytes.copy(buf, pos); pos += workstationBytes.length;
+	lmChallengeResponse.copy(buf, pos); pos += lmChallengeResponse.length;
+	ntChallengeResponse.copy(buf, pos); pos += ntChallengeResponse.length;
+	encryptedRandomSessionKeyBytes.copy(buf, pos); pos += encryptedRandomSessionKeyBytes.length;
+
+	return 'NTLM ' + buf.toString('base64');
+}
+
+function create_LM_hashed_password_v1(password){
+	// fix the password length to 14 bytes
+	password = password.toUpperCase();
+	var passwordBytes = new Buffer(password, 'ascii');
+
+	var passwordBytesPadded = new Buffer(14);
+	passwordBytesPadded.fill("\0");
+	var sourceEnd = 14;
+	if(passwordBytes.length < 14) sourceEnd = passwordBytes.length;
+	passwordBytes.copy(passwordBytesPadded, 0, 0, sourceEnd);
+
+	// split into 2 parts of 7 bytes:
+	var firstPart = passwordBytesPadded.slice(0,7);
+	var secondPart = passwordBytesPadded.slice(7);
+
+	function encrypt(buf){
+		var key = insertZerosEvery7Bits(buf);
+		var des = crypto.createCipheriv('DES-ECB', key, '');
+		return des.update("KGS!@#$%"); // page 57 in [MS-NLMP]);
+	}
+
+	var firstPartEncrypted = encrypt(firstPart);
+	var secondPartEncrypted = encrypt(secondPart);
+
+	return Buffer.concat([firstPartEncrypted, secondPartEncrypted]);
+}
+
+function insertZerosEvery7Bits(buf){
+	var binaryArray = bytes2binaryArray(buf);
+	var newBinaryArray = [];
+	for(var i=0; i<binaryArray.length; i++){
+		newBinaryArray.push(binaryArray[i]);
+
+		if((i+1)%7 === 0){
+			newBinaryArray.push(0);
+		}
+	}
+	return binaryArray2bytes(newBinaryArray);
+}
+
+function bytes2binaryArray(buf){
+	var hex2binary = {
+		0: [0,0,0,0],
+		1: [0,0,0,1],
+		2: [0,0,1,0],
+		3: [0,0,1,1],
+		4: [0,1,0,0],
+		5: [0,1,0,1],
+		6: [0,1,1,0],
+		7: [0,1,1,1],
+		8: [1,0,0,0],
+		9: [1,0,0,1],
+		A: [1,0,1,0],
+		B: [1,0,1,1],
+		C: [1,1,0,0],
+		D: [1,1,0,1],
+		E: [1,1,1,0],
+		F: [1,1,1,1]
+	};
+
+	var hexString = buf.toString('hex').toUpperCase();
+	var array = [];
+	for(var i=0; i<hexString.length; i++){
+   		var hexchar = hexString.charAt(i);
+   		array = array.concat(hex2binary[hexchar]);
+   	}
+   	return array;
+}
+
+function binaryArray2bytes(array){
+	var binary2hex = {
+		'0000': 0,
+		'0001': 1,
+		'0010': 2,
+		'0011': 3,
+		'0100': 4,
+		'0101': 5,
+		'0110': 6,
+		'0111': 7,
+		'1000': 8,
+		'1001': 9,
+		'1010': 'A',
+		'1011': 'B',
+		'1100': 'C',
+		'1101': 'D',
+		'1110': 'E',
+		'1111': 'F'
+	};
+
+ 	var bufArray = [];
+
+	for(var i=0; i<array.length; i +=8 ){
+		if((i+7) > array.length)
+			break;
+
+		var binString1 = '' + array[i] + '' + array[i+1] + '' + array[i+2] + '' + array[i+3];
+		var binString2 = '' + array[i+4] + '' + array[i+5] + '' + array[i+6] + '' + array[i+7];
+   		var hexchar1 = binary2hex[binString1];
+   		var hexchar2 = binary2hex[binString2];
+
+   		var buf = new Buffer(hexchar1 + '' + hexchar2, 'hex');
+   		bufArray.push(buf);
+   	}
+
+   	return Buffer.concat(bufArray);
+}
+
+function create_NT_hashed_password_v1(password){
+	var buf = new Buffer(password, 'utf16le');
+	var md4 = crypto.createHash('md4');
+	md4.update(buf);
+	return new Buffer(md4.digest());
+}
+
+function calc_resp(password_hash, server_challenge){
+    // padding with zeros to make the hash 21 bytes long
+    var passHashPadded = new Buffer(21);
+    passHashPadded.fill("\0");
+    password_hash.copy(passHashPadded, 0, 0, password_hash.length);
+
+    var resArray = [];
+
+    var des = crypto.createCipheriv('DES-ECB', insertZerosEvery7Bits(passHashPadded.slice(0,7)), '');
+    resArray.push( des.update(server_challenge.slice(0,8)) );
+
+    des = crypto.createCipheriv('DES-ECB', insertZerosEvery7Bits(passHashPadded.slice(7,14)), '');
+    resArray.push( des.update(server_challenge.slice(0,8)) );
+
+    des = crypto.createCipheriv('DES-ECB', insertZerosEvery7Bits(passHashPadded.slice(14,21)), '');
+    resArray.push( des.update(server_challenge.slice(0,8)) );
+
+   	return Buffer.concat(resArray);
+}
+
+function ntlm2sr_calc_resp(responseKeyNT, serverChallenge, clientChallenge){
+	// padding with zeros to make the hash 16 bytes longer
+    var lmChallengeResponse = new Buffer(clientChallenge.length + 16);
+    lmChallengeResponse.fill("\0");
+    clientChallenge.copy(lmChallengeResponse, 0, 0, clientChallenge.length);
+
+    var buf = Buffer.concat([serverChallenge, clientChallenge]);
+    var md5 = crypto.createHash('md5');
+    md5.update(buf);
+    var sess = md5.digest();
+    var ntChallengeResponse = calc_resp(responseKeyNT, sess.slice(0,8));
+
+    return {
+    	lmChallengeResponse: lmChallengeResponse,
+    	ntChallengeResponse: ntChallengeResponse
+    };
+}
+
+exports.createType1Message = createType1Message;
+exports.parseType2Message = parseType2Message;
+exports.createType3Message = createType3Message;
+
+
+
+

--- a/api/opensource/node-http-ntlm/readme.txt
+++ b/api/opensource/node-http-ntlm/readme.txt
@@ -1,0 +1,6 @@
+// This software (ntlm.js) was copied from a file of the same name at https://github.com/SamDecrock/node-http-ntlm/blob/master/ntlm.js.
+//
+// As of this writing, it is a part of the node-http-ntlm module produced by SamDecrock.
+//
+// It is used as a part of the NTLM support provided by the vso-node-api library.
+//

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,7 +39,7 @@ gulp.task('compile', ['clean'], function () {
 
 
 gulp.task('publishBuild', ['compile'], function () {
-    return gulp.src(['api/**/*.js'])
+    return gulp.src(['api/**/*.js', 'api/**/opensource/**'])
         .pipe(gulp.dest('_build'));
 });
 
@@ -60,7 +60,7 @@ gulp.task('copy', ['compile'], function () {
 
 gulp.task('postPublish', ['publishDefinitions', 'publishBuild', 'copy'], function () {
 
-    return del(['api/**/*.js']);
+    return del(['api/**/*.js', '!api/opensource/**/*.js']);
     //done();
 });
 

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for Node.js v0.10.1
 // Project: http://nodejs.org/
-// Definitions by: Microsoft TypeScript <http://typescriptlang.org>, DefinitelyTyped <https://github.com/borisyankov/DefinitelyTyped>
-// Definitions: https://github.com/borisyankov/DefinitelyTyped
+// Definitions by: Microsoft TypeScript <http://typescriptlang.org>, DefinitelyTyped <https://github.com/DefinitelyTyped/DefinitelyTyped>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /************************************************
 *                                               *
@@ -29,7 +29,7 @@ declare function clearImmediate(immediateId: any): void;
 
 declare var require: {
     (id: string): any;
-    resolve(id: string): string;
+    resolve(id:string): string;
     cache: any;
     extensions: any;
     main: any;
@@ -60,7 +60,7 @@ declare var SlowBuffer: {
 
 
 // Buffer class
-interface Buffer extends NodeBuffer { }
+interface Buffer extends NodeBuffer {}
 declare var Buffer: {
     new (str: string, encoding?: string): Buffer;
     new (size: number): Buffer;
@@ -79,18 +79,19 @@ declare var Buffer: {
 ************************************************/
 declare module NodeJS {
     export interface ErrnoException extends Error {
-        errno?: any;
+        errno?: number;
         code?: string;
         path?: string;
         syscall?: string;
+        stack?: string;
     }
 
     export interface EventEmitter {
-        addListener(event: string, listener: Function): EventEmitter;
-        on(event: string, listener: Function): EventEmitter;
-        once(event: string, listener: Function): EventEmitter;
-        removeListener(event: string, listener: Function): EventEmitter;
-        removeAllListeners(event?: string): EventEmitter;
+        addListener(event: string, listener: Function): this;
+        on(event: string, listener: Function): this;
+        once(event: string, listener: Function): this;
+        removeListener(event: string, listener: Function): this;
+        removeAllListeners(event?: string): this;
         setMaxListeners(n: number): void;
         listeners(event: string): Function[];
         emit(event: string, ...args: any[]): boolean;
@@ -120,7 +121,7 @@ declare module NodeJS {
         end(str: string, encoding?: string, cb?: Function): void;
     }
 
-    export interface ReadWriteStream extends ReadableStream, WritableStream { }
+    export interface ReadWriteStream extends ReadableStream, WritableStream {}
 
     export interface Process extends EventEmitter {
         stdout: WritableStream;
@@ -175,7 +176,7 @@ declare module NodeJS {
                 visibility: string;
             };
         };
-        kill(pid: number, signal?: string): void;
+        kill(pid:number, signal?: string|number): void;
         pid: number;
         title: string;
         arch: string;
@@ -184,15 +185,15 @@ declare module NodeJS {
         nextTick(callback: Function): void;
         umask(mask?: number): number;
         uptime(): number;
-        hrtime(time?: number[]): number[];
+        hrtime(time?:number[]): number[];
 
         // Worker
-        send? (message: any, sendHandle?: any): void;
+        send?(message: any, sendHandle?: any): void;
     }
 
     export interface Timer {
-        ref(): void;
-        unref(): void;
+        ref() : void;
+        unref() : void;
     }
 }
 
@@ -207,7 +208,7 @@ interface NodeBuffer {
     length: number;
     copy(targetBuffer: Buffer, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
     slice(start?: number, end?: number): Buffer;
-    readUInt8(offset: number, noAsset?: boolean): number;
+    readUInt8(offset: number, noAssert?: boolean): number;
     readUInt16LE(offset: number, noAssert?: boolean): number;
     readUInt16BE(offset: number, noAssert?: boolean): number;
     readUInt32LE(offset: number, noAssert?: boolean): number;
@@ -258,15 +259,15 @@ declare module "events" {
     export class EventEmitter implements NodeJS.EventEmitter {
         static listenerCount(emitter: EventEmitter, event: string): number;
 
-        addListener(event: string, listener: Function): EventEmitter;
-        on(event: string, listener: Function): EventEmitter;
-        once(event: string, listener: Function): EventEmitter;
-        removeListener(event: string, listener: Function): EventEmitter;
-        removeAllListeners(event?: string): EventEmitter;
+        addListener(event: string, listener: Function): this;
+        on(event: string, listener: Function): this;
+        once(event: string, listener: Function): this;
+        removeListener(event: string, listener: Function): this;
+        removeAllListeners(event?: string): this;
         setMaxListeners(n: number): void;
         listeners(event: string): Function[];
         emit(event: string, ...args: any[]): boolean;
-    }
+   }
 }
 
 declare module "http" {
@@ -319,51 +320,128 @@ declare module "http" {
         end(str: string, encoding?: string, cb?: Function): void;
         end(data?: any, encoding?: string): void;
     }
-    export interface ClientRequest extends events.EventEmitter, stream.Writable {
-        // Extended base methods
-        write(buffer: Buffer): boolean;
-        write(buffer: Buffer, cb?: Function): boolean;
-        write(str: string, cb?: Function): boolean;
-        write(str: string, encoding?: string, cb?: Function): boolean;
-        write(str: string, encoding?: string, fd?: string): boolean;
 
-        write(chunk: any, encoding?: string): void;
+	/**
+	 * Object returned by http.request()
+	 */
+    export interface ClientRequest extends events.EventEmitter, NodeJS.WritableStream {
         abort(): void;
         setTimeout(timeout: number, callback?: Function): void;
         setNoDelay(noDelay?: boolean): void;
         setSocketKeepAlive(enable?: boolean, initialDelay?: number): void;
-
-        // Extended base methods
-        end(): void;
-        end(buffer: Buffer, cb?: Function): void;
-        end(str: string, cb?: Function): void;
-        end(str: string, encoding?: string, cb?: Function): void;
-        end(data?: any, encoding?: string): void;
     }
-    export interface ClientResponse extends events.EventEmitter, stream.Readable {
+
+	/**
+	 * The client version of http.IncomingMessage
+	 */
+    export interface ClientResponse extends events.EventEmitter, NodeJS.ReadableStream {
         statusCode: number;
         httpVersion: string;
         headers: any;
         trailers: any;
+		socket: net.Socket;
         setEncoding(encoding?: string): void;
         pause(): void;
         resume(): void;
     }
-    export interface Agent { maxSockets: number; sockets: any; requests: any; }
+
+	export interface AgentOptions {
+		/**
+		 * Keep sockets around in a pool to be used by other requests in the future. Default = false
+		 */
+		keepAlive?: boolean;
+		/**
+		 * When using HTTP KeepAlive, how often to send TCP KeepAlive packets over sockets being kept alive. Default = 1000.
+		 * Only relevant if keepAlive is set to true.
+		 */
+		keepAliveMsecs?: number;
+		/**
+		 * Maximum number of sockets to allow per host. Default for Node 0.10 is 5, default for Node 0.12 is Infinity
+		 */
+		maxSockets?: number;
+		/**
+		 * Maximum number of sockets to leave open in a free state. Only relevant if keepAlive is set to true. Default = 256.
+		 */
+		maxFreeSockets?: number;
+	}
+
+    export class Agent {
+		maxSockets: number;
+		sockets: any;
+		requests: any;
+
+		constructor(opts?: AgentOptions);
+
+		/**
+		 * Destroy any sockets that are currently in use by the agent.
+		 * It is usually not necessary to do this. However, if you are using an agent with KeepAlive enabled,
+		 * then it is best to explicitly shut down the agent when you know that it will no longer be used. Otherwise,
+		 * sockets may hang open for quite a long time before the server terminates them.
+		 */
+		destroy(): void;
+	}
+
+	/**
+	 * Options for http.request()
+	 */
+	export interface RequestOptions {
+		/**
+		 * A domain name or IP address of the server to issue the request to. Defaults to 'localhost'.
+		 */
+		host?: string;
+		/**
+		 * To support url.parse() hostname is preferred over host
+		 */
+		hostname?: string;
+		/**
+		 * Port of remote server. Defaults to 80.
+		 */
+		port?: number;
+		/**
+		 * Local interface to bind for network connections.
+		 */
+		localAddress?: string;
+		/**
+		 * Unix Domain Socket (use one of host:port or socketPath)
+		 */
+		socketPath?: string;
+		/**
+		 * A string specifying the HTTP request method. Defaults to 'GET'.
+		 */
+		method?: string;
+		/**
+		 * Request path. Defaults to '/'. Should include query string if any. E.G. '/index.html?page=12'
+		 */
+		path?: string;
+		/**
+		 * An object containing request headers.
+		 */
+		headers?: { [index: string]: string };
+		/**
+		 * Basic authentication i.e. 'user:password' to compute an Authorization header.
+		 */
+		auth?: string;
+		/**
+		 * Controls Agent behavior. When an Agent is used request will default to Connection: keep-alive. Possible values:
+		 * - undefined (default): use global Agent for this host and port.
+		 * - Agent object: explicitly use the passed in Agent.
+		 * - false: opts out of connection pooling with an Agent, defaults request to Connection: close.
+		 */
+		agent?: Agent|boolean;
+	}
 
     export var STATUS_CODES: {
         [errorCode: number]: string;
         [errorCode: string]: string;
     };
-    export function createServer(requestListener?: (request: ServerRequest, response: ServerResponse) => void): Server;
+    export function createServer(requestListener?: (request: ServerRequest, response: ServerResponse) =>void ): Server;
     export function createClient(port?: number, host?: string): any;
-    export function request(options: any, callback?: Function): ClientRequest;
-    export function get(options: any, callback?: Function): ClientRequest;
+    export function request(options: RequestOptions, callback?: (response: ClientResponse) => void): ClientRequest;
+    export function get(options: RequestOptions, callback?: (response: ClientResponse) => void): ClientRequest;
     export var globalAgent: Agent;
 }
-
 declare module "cluster" {
-    import child = require("child_process");
+    import child  = require("child_process");
     import events = require("events");
 
     export interface ClusterSettings {
@@ -422,13 +500,13 @@ declare module "zlib" {
     export function createInflateRaw(options?: ZlibOptions): InflateRaw;
     export function createUnzip(options?: ZlibOptions): Unzip;
 
-    export function deflate(buf: Buffer, callback: (error: Error, result: any) => void): void;
-    export function deflateRaw(buf: Buffer, callback: (error: Error, result: any) => void): void;
-    export function gzip(buf: Buffer, callback: (error: Error, result: any) => void): void;
-    export function gunzip(buf: Buffer, callback: (error: Error, result: any) => void): void;
-    export function inflate(buf: Buffer, callback: (error: Error, result: any) => void): void;
-    export function inflateRaw(buf: Buffer, callback: (error: Error, result: any) => void): void;
-    export function unzip(buf: Buffer, callback: (error: Error, result: any) => void): void;
+    export function deflate(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function deflateRaw(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function gzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function gunzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function inflate(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function inflateRaw(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function unzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
 
     // Constants
     export var Z_NO_FLUSH: number;
@@ -465,7 +543,7 @@ declare module "zlib" {
 }
 
 declare module "os" {
-    export function tmpDir(): string;
+    export function tmpdir(): string;
     export function hostname(): string;
     export function type(): string;
     export function platform(): string;
@@ -528,8 +606,8 @@ declare module "https" {
     };
     export interface Server extends tls.Server { }
     export function createServer(options: ServerOptions, requestListener?: Function): Server;
-    export function request(options: RequestOptions, callback?: (res: events.EventEmitter) => void): http.ClientRequest;
-    export function get(options: RequestOptions, callback?: (res: events.EventEmitter) => void): http.ClientRequest;
+    export function request(options: RequestOptions, callback?: (res: http.ClientResponse) =>void ): http.ClientRequest;
+    export function get(options: RequestOptions, callback?: (res: http.ClientResponse) =>void ): http.ClientRequest;
     export var globalAgent: Agent;
 }
 
@@ -604,12 +682,12 @@ declare module "child_process" {
     import stream = require("stream");
 
     export interface ChildProcess extends events.EventEmitter {
-        stdin: stream.Writable;
+        stdin:  stream.Writable;
         stdout: stream.Readable;
         stderr: stream.Readable;
         pid: number;
         kill(signal?: string): void;
-        send(message: any, sendHandle?: any): void;
+        send(message: any, sendHandle: any): void;
         disconnect(): void;
     }
 
@@ -629,18 +707,22 @@ declare module "child_process" {
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
-    }, callback: (error: Error, stdout: Buffer, stderr: Buffer) => void): ChildProcess;
-    export function exec(command: string, callback: (error: Error, stdout: Buffer, stderr: Buffer) => void): ChildProcess;
-    export function execFile(file: string, args: string[], options: {
+    }, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    export function exec(command: string, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    export function execFile(file: string,
+        callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    export function execFile(file: string, args?: string[],
+        callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    export function execFile(file: string, args?: string[], options?: {
         cwd?: string;
         stdio?: any;
         customFds?: any;
         env?: any;
         encoding?: string;
         timeout?: number;
-        maxBuffer?: string;
+        maxBuffer?: number;
         killSignal?: string;
-    }, callback: (error: Error, stdout: Buffer, stderr: Buffer) => void): ChildProcess;
+    }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
     export function fork(modulePath: string, args?: string[], options?: {
         cwd?: string;
         env?: any;
@@ -650,21 +732,7 @@ declare module "child_process" {
 
 declare module "url" {
     export interface Url {
-        href: string;
-        protocol: string;
-        auth: string;
-        hostname: string;
-        port: string;
-        host: string;
-        pathname: string;
-        search: string;
-        query: any; // string | Object
-        slashes: boolean;
-        hash?: string;
-        path?: string;
-    }
-
-    export interface UrlOptions {
+        href?: string;
         protocol?: string;
         auth?: string;
         hostname?: string;
@@ -672,29 +740,30 @@ declare module "url" {
         host?: string;
         pathname?: string;
         search?: string;
-        query?: any;
+        query?: any; // string | Object
+        slashes?: boolean;
         hash?: string;
         path?: string;
     }
 
-    export function parse(urlStr: string, parseQueryString?: boolean, slashesDenoteHost?: boolean): Url;
-    export function format(url: UrlOptions): string;
+    export function parse(urlStr: string, parseQueryString?: boolean , slashesDenoteHost?: boolean ): Url;
+    export function format(url: Url): string;
     export function resolve(from: string, to: string): string;
 }
 
 declare module "dns" {
-    export function lookup(domain: string, family: number, callback: (err: Error, address: string, family: number) => void): string;
-    export function lookup(domain: string, callback: (err: Error, address: string, family: number) => void): string;
-    export function resolve(domain: string, rrtype: string, callback: (err: Error, addresses: string[]) => void): string[];
-    export function resolve(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
-    export function resolve4(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
-    export function resolve6(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
-    export function resolveMx(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
-    export function resolveTxt(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
-    export function resolveSrv(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
-    export function resolveNs(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
-    export function resolveCname(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
-    export function reverse(ip: string, callback: (err: Error, domains: string[]) => void): string[];
+    export function lookup(domain: string, family: number, callback: (err: Error, address: string, family: number) =>void ): string;
+    export function lookup(domain: string, callback: (err: Error, address: string, family: number) =>void ): string;
+    export function resolve(domain: string, rrtype: string, callback: (err: Error, addresses: string[]) =>void ): string[];
+    export function resolve(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
+    export function resolve4(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
+    export function resolve6(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
+    export function resolveMx(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
+    export function resolveTxt(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
+    export function resolveSrv(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
+    export function resolveNs(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
+    export function resolveCname(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
+    export function reverse(ip: string, callback: (err: Error, domains: string[]) =>void ): string[];
 }
 
 declare module "net" {
@@ -749,12 +818,12 @@ declare module "net" {
         maxConnections: number;
         connections: number;
     }
-    export function createServer(connectionListener?: (socket: Socket) => void): Server;
-    export function createServer(options?: { allowHalfOpen?: boolean; }, connectionListener?: (socket: Socket) => void): Server;
-    export function connect(options: { allowHalfOpen?: boolean; }, connectionListener?: Function): Socket;
+    export function createServer(connectionListener?: (socket: Socket) =>void ): Server;
+    export function createServer(options?: { allowHalfOpen?: boolean; }, connectionListener?: (socket: Socket) =>void ): Server;
+    export function connect(options: { port: number, host?: string, localAddress? : string, allowHalfOpen?: boolean; }, connectionListener?: Function): Socket;
     export function connect(port: number, host?: string, connectionListener?: Function): Socket;
     export function connect(path: string, connectionListener?: Function): Socket;
-    export function createConnection(options: { allowHalfOpen?: boolean; }, connectionListener?: Function): Socket;
+    export function createConnection(options: { port: number, host?: string, localAddress? : string, allowHalfOpen?: boolean; }, connectionListener?: Function): Socket;
     export function createConnection(port: number, host?: string, connectionListener?: Function): Socket;
     export function createConnection(path: string, connectionListener?: Function): Socket;
     export function isIP(input: string): number;
@@ -823,8 +892,13 @@ declare module "fs" {
         close(): void;
     }
 
-    export interface ReadStream extends stream.Readable { }
-    export interface WriteStream extends stream.Writable { }
+    export interface ReadStream extends stream.Readable {
+        close(): void;
+    }
+    export interface WriteStream extends stream.Writable {
+        close(): void;
+        bytesWritten: number;
+    }
 
     export function rename(oldPath: string, newPath: string, callback?: (err?: NodeJS.ErrnoException) => void): void;
     export function renameSync(oldPath: string, newPath: string): void;
@@ -865,8 +939,8 @@ declare module "fs" {
     export function readlink(path: string, callback?: (err: NodeJS.ErrnoException, linkString: string) => any): void;
     export function readlinkSync(path: string): string;
     export function realpath(path: string, callback?: (err: NodeJS.ErrnoException, resolvedPath: string) => any): void;
-    export function realpath(path: string, cache: { [path: string]: string }, callback: (err: NodeJS.ErrnoException, resolvedPath: string) => any): void;
-    export function realpathSync(path: string, cache?: { [path: string]: string }): string;
+    export function realpath(path: string, cache: {[path: string]: string}, callback: (err: NodeJS.ErrnoException, resolvedPath: string) =>any): void;
+    export function realpathSync(path: string, cache?: {[path: string]: string}): string;
     export function unlink(path: string, callback?: (err?: NodeJS.ErrnoException) => void): void;
     export function unlinkSync(path: string): void;
     export function rmdir(path: string, callback?: (err?: NodeJS.ErrnoException) => void): void;
@@ -902,7 +976,7 @@ declare module "fs" {
     export function readFile(filename: string, encoding: string, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
     export function readFile(filename: string, options: { encoding: string; flag?: string; }, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
     export function readFile(filename: string, options: { flag?: string; }, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
-    export function readFile(filename: string, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
+    export function readFile(filename: string, callback: (err: NodeJS.ErrnoException, data: Buffer) => void ): void;
     export function readFileSync(filename: string, encoding: string): string;
     export function readFileSync(filename: string, options: { encoding: string; flag?: string; }): string;
     export function readFileSync(filename: string, options?: { flag?: string; }): Buffer;
@@ -1042,10 +1116,10 @@ declare module "tls" {
         cleartext: any;
     }
 
-    export function createServer(options: TlsOptions, secureConnectionListener?: (cleartextStream: ClearTextStream) => void): Server;
-    export function connect(options: TlsOptions, secureConnectionListener?: () => void): ClearTextStream;
-    export function connect(port: number, host?: string, options?: ConnectionOptions, secureConnectListener?: () => void): ClearTextStream;
-    export function connect(port: number, options?: ConnectionOptions, secureConnectListener?: () => void): ClearTextStream;
+    export function createServer(options: TlsOptions, secureConnectionListener?: (cleartextStream: ClearTextStream) =>void ): Server;
+    export function connect(options: TlsOptions, secureConnectionListener?: () =>void ): ClearTextStream;
+    export function connect(port: number, host?: string, options?: ConnectionOptions, secureConnectListener?: () =>void ): ClearTextStream;
+    export function connect(port: number, options?: ConnectionOptions, secureConnectListener?: () =>void ): ClearTextStream;
     export function createSecurePair(credentials?: crypto.Credentials, isServer?: boolean, requestCert?: boolean, rejectUnauthorized?: boolean): SecurePair;
 }
 
@@ -1117,12 +1191,12 @@ declare module "crypto" {
         setPrivateKey(public_key: string, encoding?: string): void;
     }
     export function getDiffieHellman(group_name: string): DiffieHellman;
-    export function pbkdf2(password: string, salt: string, iterations: number, keylen: number, callback: (err: Error, derivedKey: Buffer) => any): void;
-    export function pbkdf2Sync(password: string, salt: string, iterations: number, keylen: number): Buffer;
+    export function pbkdf2(password: string|Buffer, salt: string|Buffer, iterations: number, keylen: number, callback: (err: Error, derivedKey: Buffer) => any): void;
+    export function pbkdf2Sync(password: string|Buffer, salt: string|Buffer, iterations: number, keylen: number) : Buffer;
     export function randomBytes(size: number): Buffer;
-    export function randomBytes(size: number, callback: (err: Error, buf: Buffer) => void): void;
+    export function randomBytes(size: number, callback: (err: Error, buf: Buffer) =>void ): void;
     export function pseudoRandomBytes(size: number): Buffer;
-    export function pseudoRandomBytes(size: number, callback: (err: Error, buf: Buffer) => void): void;
+    export function pseudoRandomBytes(size: number, callback: (err: Error, buf: Buffer) =>void ): void;
 }
 
 declare module "stream" {
@@ -1157,6 +1231,7 @@ declare module "stream" {
     export interface WritableOptions {
         highWaterMark?: number;
         decodeStrings?: boolean;
+        objectMode?: boolean;
     }
 
     export class Writable extends events.EventEmitter implements NodeJS.WritableStream {
@@ -1192,7 +1267,7 @@ declare module "stream" {
         end(str: string, encoding?: string, cb?: Function): void;
     }
 
-    export interface TransformOptions extends ReadableOptions, WritableOptions { }
+    export interface TransformOptions extends ReadableOptions, WritableOptions {}
 
     // Note: Transform lacks the _read and _write methods of Readable/Writable.
     export class Transform extends events.EventEmitter implements NodeJS.ReadWriteStream {
@@ -1221,7 +1296,7 @@ declare module "stream" {
         end(str: string, encoding?: string, cb?: Function): void;
     }
 
-    export class PassThrough extends Transform { }
+    export class PassThrough extends Transform {}
 }
 
 declare module "util" {
@@ -1248,8 +1323,8 @@ declare module "util" {
 }
 
 declare module "assert" {
-    function internal(value: any, message?: string): void;
-    module internal {
+    function internal (value: any, message?: string): void;
+    namespace internal {
         export class AssertionError implements Error {
             name: string;
             message: string;
@@ -1258,10 +1333,8 @@ declare module "assert" {
             operator: string;
             generatedMessage: boolean;
 
-            constructor(options?: {
-                message?: string; actual?: any; expected?: any;
-                operator?: string; stackStartFunction?: Function
-            });
+            constructor(options?: {message?: string; actual?: any; expected?: any;
+                                  operator?: string; stackStartFunction?: Function});
         }
 
         export function fail(actual?: any, expected?: any, message?: string, operator?: string): void;
@@ -1316,12 +1389,6 @@ declare module "domain" {
         bind(cb: (err: Error, data: any) => any): any;
         intercept(cb: (data: any) => any): any;
         dispose(): void;
-
-        addListener(event: string, listener: Function): Domain;
-        on(event: string, listener: Function): Domain;
-        once(event: string, listener: Function): Domain;
-        removeListener(event: string, listener: Function): Domain;
-        removeAllListeners(event?: string): Domain;
     }
 
     export function create(): Domain;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vso-node-api",
   "description": "Node client for Visual Studio Online/TFS REST APIs",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "main": "./WebApi.js",
   "repository": {
     "type": "git",
@@ -15,7 +15,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "q": "^1.0.1"
+    "q": "^1.0.1",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "del": "^1.1.1",


### PR DESCRIPTION
(Pending code scan of node-http-ntlm; already in progress.)

Add an NTLM handler using portions of the node-http-ntlm package.  Caller provides username and password (and optional domain and workstation) to create the handler.  Added two methods to IRequestHandler to determine if the handler can handle the particular type of authentication (e.g., NTLM).  I considered adding a new interface but it ended up making the code where the RequestHandler is used more complex (WebApi.ts) so I went the simpler route.

Updated node.d.ts with file from DefinitelyTyped (the ntlm support required the AgentOptions interface exposed by node).  Note that the version of Node.js (0.10.1) remains the same.

Took a dependency on underscore, received OSS approval and added ThirdPartyNotices.txt.

Updated Copyright line in LICENSE file per guidance from legal.

Regression tested on Ubuntu VM with xplat build agent.  Created a build definition that ran an Ant build and uploaded JAR files as artifacts.  Configuration of the build agent and builds on the build definition succeeded.

Manually testing the NTLM changes with the VS Code extension (currently in progress).
