### PR TITLE
Disable proxy for NTLM authentication

### DIFF
--- a/api/handlers/ntlm.ts
+++ b/api/handlers/ntlm.ts
@@ -27,6 +27,10 @@ export class NtlmCredentialHandler implements VsoBaseInterfaces.IRequestHandler 
 
     prepareRequest(options:any): void {
         // No headers or options need to be set.  We keep the credentials on the handler itself.
+        // If a (proxy) agent is set, remove it as we don't support proxy for NTLM at this time
+        if (options.agent) {
+            delete options.agent;
+        }
     }
 
     canHandleAuthentication(res: VsoBaseInterfaces.IHttpResponse): boolean {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vso-node-api",
   "description": "Node client for Visual Studio Online/TFS REST APIs",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "main": "./WebApi.js",
   "typings": "./WebApi.d.ts",
   "scripts": {


### PR DESCRIPTION
The proxy support in vsts-node-api v4+ prevents existing NTLM authentication from working properly.  For now, disable the proxy support in the NTLM auth handler.  (The proxy support will still be used for Team Services.)
