### PR TITLE
WebApi.ts new NtlmCredetialHandler initialization was wrong order

### DIFF
--- a/api/handlers/ntlm.ts
+++ b/api/handlers/ntlm.ts
@@ -14,14 +14,14 @@ export class NtlmCredentialHandler implements VsoBaseInterfaces.IRequestHandler 
     workstation: string;
     domain: string;
 
-    constructor(username: string, password: string,  domain?: string, workstation?: string) {
+    constructor(username: string, password: string,  workstation?: string, domain?: string) {
         this.username = username;
         this.password = password;
-        if (domain !== undefined) {
-            this.domain = domain;
-        }
         if (workstation !== undefined) {
             this.workstation = workstation;
+        }
+        if (domain !== undefined) {
+            this.domain = domain;
         }
     }
 


### PR DESCRIPTION
WebApi.ts new NtlmCredetialHandler initialization was wrong order at line39. workstation and domain order parameters are being set in reverse order.
Because it is exported in that order at WebApi.ts, I changed the constructor signature in ntlm.ts instead of changing WebApits

Fix #69