### PR TITLE
Correct ChangeCountDictionary interface definition

### DIFF
--- a/api/interfaces/GitInterfaces.ts
+++ b/api/interfaces/GitInterfaces.ts
@@ -58,6 +58,21 @@ export interface Change<T> {
 }
 
 export interface ChangeCountDictionary {
+    None?: number;
+    Add?: number;
+    Edit?: number;
+    Encoding?: number;
+    Rename?: number;
+    Delete?: number;
+    Undelete?: number;
+    Branch?: number;
+    Merge?: number;
+    Lock?: number;
+    Rollback?: number;
+    SourceRename?: number;
+    TargetRename?: number;
+    Property?: number;
+    All?: number;
 }
 
 export interface ChangeList<T> {


### PR DESCRIPTION
The type definition for interface ChangeCountDictionary was empty. This PR adds the definition for optional dictionary keys with number values that can be returned.