### PR TITLE
Allow custom User-Agent header

### DIFF
--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -87,10 +87,17 @@ export class WebApi {
      * @param authHandler default authentication credentials to use when creating new apis from factory methods
      */
     constructor(defaultUrl: string, authHandler: VsoBaseInterfaces.IRequestHandler, options?: VsoBaseInterfaces.IRequestOptions) {
+        let userAgent = 'vsts-node-api';
         this.serverUrl = defaultUrl;
         this.authHandler = authHandler;
         this.options = options;
-        this.rest = new rm.RestClient('vsts-node-api', null, [this.authHandler], options);
+
+        if (options.hasOwnProperty('userAgent')) {
+            userAgent = options.userAgent;
+            delete options.userAgent;
+        }
+
+        this.rest = new rm.RestClient(userAgent, null, [this.authHandler], options);
         this.vsoClient = new vsom.VsoClient(defaultUrl, this.rest);
     }
 

--- a/api/interfaces/common/VsoBaseInterfaces.ts
+++ b/api/interfaces/common/VsoBaseInterfaces.ts
@@ -66,7 +66,8 @@ export interface IHttpResponse {
 export interface IRequestOptions {
     socketTimeout?: number,
     ignoreSslError?: boolean,
-    proxy?: IProxyConfiguration
+    proxy?: IProxyConfiguration,
+    userAgent?: string
 }
 
 export interface IProxyConfiguration {


### PR DESCRIPTION
Gaurav Saral (@gsaralms?) suggested setting a custom `User-Agent` before calling VSTS from the work I'm currently doing.

There also seems to be some interest in this over at #90, although this is a far less convenient approach. Maybe a place to start iterating from?

I'm not super well versed in TypeScript, so please suggest any improvements you can think of.