### PR TITLE
Fix for requeuePolicyEvaluation failing to set api-version correctly.

### DIFF
--- a/api/PolicyApi.ts
+++ b/api/PolicyApi.ts
@@ -318,7 +318,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
                     verData.apiVersion);
 
                 let res: restm.IRestResponse<PolicyInterfaces.PolicyEvaluationRecord>;
-                res = await this.rest.update<PolicyInterfaces.PolicyEvaluationRecord>(url, options);
+                res = await this.rest.update<PolicyInterfaces.PolicyEvaluationRecord>(url, null, options);
 
                 let ret = this.formatResponse(res.result,
                     PolicyInterfaces.TypeInfo.PolicyEvaluationRecord,


### PR DESCRIPTION
The rest.update() call doesn't have a body, so need to pass null for the 2nd argument. The accept header is incorrect otherwise.
I'm using 6.2.8-preview, but this appears to still be the case.