### PR TITLE
fix bad parameter order in rest.replace in addBuildTag\addDefinitionTag

### DIFF
--- a/api/BuildApi.ts
+++ b/api/BuildApi.ts
@@ -2260,7 +2260,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                                                                                 verData.apiVersion);
 
                 let res: restm.IRestResponse<string[]>;
-                res = await this.rest.replace<string[]>(url, options);
+                res = await this.rest.replace<string[]>(url, null, options);
 
                 let ret = this.formatResponse(res.result,
                                               null,
@@ -2444,7 +2444,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                                                                                 verData.apiVersion);
 
                 let res: restm.IRestResponse<string[]>;
-                res = await this.rest.replace<string[]>(url, options);
+                res = await this.rest.replace<string[]>(url, null, options);
 
                 let ret = this.formatResponse(res.result,
                                               null,


### PR DESCRIPTION
The bad parameter ordering here causes the options to be ignored and thus makes the api call fail.