### PR TITLE
Add types definition for main js file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vso-node-api",
     "description": "Node client for Visual Studio Online/TFS REST APIs",
-    "version": "6.5.0",
+    "version": "6.5.1",
     "main": "./WebApi.js",
     "types" : "./WebApi.d.ts",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "description": "Node client for Visual Studio Online/TFS REST APIs",
     "version": "6.5.0",
     "main": "./WebApi.js",
+    "types" : "./WebApi.d.ts",
     "scripts": {
         "build": "node make.js build",
         "test": "node make.js test",


### PR DESCRIPTION
Fixes #169. When I removed Typings I removed the .d.ts reference for the main js file and didn't replace it with a types property referencing the same type definition file.

Also created #171 to install a as a packed module when running samples to catch issues like this in the future.
