### PR TITLE
Made all GitRepositoryCreateOptions properties optional

### DIFF
--- a/api/interfaces/GitInterfaces.ts
+++ b/api/interfaces/GitInterfaces.ts
@@ -2142,9 +2142,9 @@ export interface GitRepository {
 }
 
 export interface GitRepositoryCreateOptions {
-    name: string;
-    parentRepository: GitRepositoryRef;
-    project: TfsCoreInterfaces.TeamProjectReference;
+    name?: string;
+    parentRepository?: GitRepositoryRef;
+    project?: TfsCoreInterfaces.TeamProjectReference;
 }
 
 export interface GitRepositoryRef {


### PR DESCRIPTION
According to the [VSTS REST docs](https://docs.microsoft.com/en-us/rest/api/vsts/git/repositories/create), none of these options are required. That should be reflected in `GitAPI.createRepository()`. I'm honestly unsure why it would make sense to create a repository without a name (just following the docs here), but `parentRepository` and `project` are definitely not needed.