### PR TITLE
Use accountURL instead of collectionURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ npm install vso-node-api --save
 ```javascript
 let vsts = require('vso-node-api');
 
-// your collection url
-let collectionUrl = "https://fabrikam.visualstudio.com/defaultcollection";
+// your account url
+let accountUrl = "https://fabrikam.visualstudio.com/";
 
 // ideally from config
 let token: string = "cbdeb34vzyuk5l4gxc4qfczn3lko3avfkfqyb47etahq6axpcqha"; 
 
 let authHandler = vsts.getPersonalAccessTokenHandler(token); 
-let connect = new vsts.WebApi(collectionUrl, authHandler);    
+let connect = new vsts.WebApi(accountUrl, authHandler);    
 ```
 
 ### Get an instance of a client


### PR DESCRIPTION
When using a collectionURL, the sample will simply not work. Even worse, it will blow up with:

```
node main.js
TypeError: Cannot read property 'value' of undefined
    at restClient.options.then (/Users/joao/Work/vsts-build-status/node_modules/vso-node-api/VsoClient.js:130:60)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```

It seems that the right thing to do here is to use the account URL instead.