### PR TITLE
Formatting request URL now handles Dates

### DIFF
--- a/api/VsoClient.ts
+++ b/api/VsoClient.ts
@@ -192,10 +192,10 @@ export class VsoClient {
                 let prop = object[property];
                 let valueString = this.getValueString(property, prop);
                 if (first && prop !== undefined) {
-                    value += property + "=" + valueString;
+                    value += valueString;
                     first = false;
                 } else if (prop !== undefined) {
-                    value += "&" + property +"=" + valueString;
+                    value += "&" + valueString;
                 }
             }
         }

--- a/api/VsoClient.ts
+++ b/api/VsoClient.ts
@@ -190,11 +190,12 @@ export class VsoClient {
         for (let property in object) {
             if (object.hasOwnProperty(property)) {
                 let prop = object[property];
+                let valueString = this.getValueString(property, prop);
                 if (first && prop !== undefined) {
-                    value += property + "=" + encodeURIComponent(prop);
+                    value += property + "=" + valueString;
                     first = false;
                 } else if (prop !== undefined) {
-                    value += "&" + property +"=" + encodeURIComponent(prop);
+                    value += "&" + property +"=" + valueString;
                 }
             }
         }
@@ -204,6 +205,16 @@ export class VsoClient {
         }
 
         return value;
+    }
+
+    protected getValueString(queryValue, value) {
+        let valueString = null;
+        if (typeof(value) === 'object') {
+            valueString = this.getSerializedObject(queryValue, value);
+        } else {
+            valueString = queryValue + "=" + encodeURIComponent(value);
+        }
+        return valueString;
     }
 
     protected getRequestUrl(routeTemplate: string, area: string, resource: string, routeValues: any, queryParams?: any): string {
@@ -225,12 +236,7 @@ export class VsoClient {
         for (let queryValue in queryParams) {
             if (queryParams[queryValue] != null) {
                 let value = queryParams[queryValue];
-                let valueString = null;
-                if (typeof(value) === 'object') {
-                    valueString = this.getSerializedObject(queryValue, value);
-                } else {
-                    valueString = queryValue + "=" + encodeURIComponent(queryParams[queryValue]);
-                }
+                let valueString = this.getValueString(queryValue, value);
                 if (first) {
                     relativeUrl += "?" + valueString;
                     first = false;

--- a/api/VsoClient.ts
+++ b/api/VsoClient.ts
@@ -183,7 +183,7 @@ export class VsoClient {
         return url.resolve(this.baseUrl, path.join(this.basePath, relativeUrl));
     }
 
-    private getSerializedObject(object: any): string {
+    private getSerializedObject(queryValue: any, object: any): string {
         let value:string = "";
         let first:boolean = true;
 
@@ -197,6 +197,10 @@ export class VsoClient {
                     value += "&" + property +"=" + encodeURIComponent(prop);
                 }
             }
+        }
+
+        if (value == ""){
+            value += queryValue + "=" + object.toString();
         }
 
         return value;
@@ -223,7 +227,7 @@ export class VsoClient {
                 let value = queryParams[queryValue];
                 let valueString = null;
                 if (typeof(value) === 'object') {
-                    valueString = this.getSerializedObject(value);
+                    valueString = this.getSerializedObject(queryValue, value);
                 } else {
                     valueString = queryValue + "=" + encodeURIComponent(queryParams[queryValue]);
                 }


### PR DESCRIPTION
Currently, when getRequestURL() is passed a Date, it passes it on to getSerializedObject() which returns "". This results in a "&" being appended to the URL, causing requests to fail. This fixes that problem for Dates and other objects without any of its own properties to iterate over.

In addition, getSerializedObject() is currently only able to serialize objects that are one level deep, this allows for nested objects to be serialized.

Fixes #98, fixes #191, and fixes #199 